### PR TITLE
Feature/adding links of internal pages

### DIFF
--- a/src/components/CommonQuestions/index.tsx
+++ b/src/components/CommonQuestions/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Logo, Typography } from '..';
 import * as S from './styles';
 
@@ -15,7 +16,11 @@ export type CommonQuestionsProps = {
 export const CommonQuestions = ({ title, questions }: CommonQuestionsProps) => (
   <S.CommonQuestionsSection>
     <header>
-      <Logo width={48} height={68} priority quality={30} />
+      <Link href="/">
+        <a>
+          <Logo width={48} height={68} priority quality={30} />
+        </a>
+      </Link>
     </header>
 
     <S.CommonQestionsSectionTitle

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -4,11 +4,16 @@ import * as S from './styles';
 import { Typography } from '../Typography';
 
 import { Logo } from '../Logo';
+import Link from 'next/link';
 
 export const Footer = () => (
   <S.FooterWrapper>
     <S.FooterContainer>
-      <Logo width={65} height={94} />
+      <Link href="/">
+        <a>
+          <Logo width={65} height={94} />
+        </a>
+      </Link>
       <S.FooterContent>
         <Typography variant="body1" weight="700">
           Estartando Devs
@@ -16,6 +21,12 @@ export const Footer = () => (
         <SocialShareButtons />
       </S.FooterContent>
     </S.FooterContainer>
+    <S.DoubtsLinkWrapper>
+      <Typography variant="body3">{`Dúvidas? Veja as`}</Typography>
+      <S.DoubtsLink>
+        <Link href="/perguntas-frequentes">{`perguntas mais frequentes`}</Link>
+      </S.DoubtsLink>
+    </S.DoubtsLinkWrapper>
     <S.CopyContainer>
       <Typography variant="body3" weight="400">
         © Estartando Devs 2022

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -4,17 +4,18 @@ import { Typography } from '../Typography';
 export const FooterWrapper = styled.footer`
   display: flex;
   flex-direction: column;
+  gap: 1.25rem;
 `;
 
 export const FooterContainer = styled.section`
   width: 100%;
   display: flex;
   justify-content: center;
-  gap: 24px;
+  gap: 1.25rem;
   border-top: 1px solid ${({ theme }) => theme.palette.gray[2]};
-  padding: 80px 0;
+  padding: 5rem 0 1rem;
   @media (max-width: ${({ theme: { media } }) => media.tablet}) {
-    padding: 40px 0;
+    padding: 2.5rem 0 1rem;
   }
 `;
 
@@ -23,14 +24,34 @@ export const FooterContent = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   align-items: flex-start;
-  gap: 16px;
+  gap: 1rem;
+`;
+
+export const DoubtsLinkWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: nowrap;
+  gap: 0.3125rem;
+  p {
+    white-space: nowrap;
+  }
+`;
+
+export const DoubtsLink = styled(Typography).attrs({
+  variant: 'body3',
+})`
+  border-bottom: 1px solid ${({ theme: { palette } }) => palette.design.purple};
+  cursor: pointer;
+  a {
+    color: ${({ theme }) => theme.palette.design.white};
+  }
 `;
 
 export const CopyContainer = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0.625rem 0;
+  padding: 0 0 0.625rem;
 `;
 
 export const CopyText = styled(Typography)`


### PR DESCRIPTION
## Description
Com a remoção da seção de inscreva-se estávamos sem link para `perguntas-frequentes`. Nesse pr adiciono o mesmo link no footer e link para home nas logos.

## Screenshots / Videos
![image](https://user-images.githubusercontent.com/34426836/159825355-fe8e78ef-16c0-4403-ab10-9cf7b7c183b6.png)

![image](https://user-images.githubusercontent.com/34426836/159825263-fb945df7-30e9-434c-94b1-b02c5c014c20.png)
## Developer Checks

- [x] PR title & commits adhere to [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR is targeting correct branch, is up-to-date, & no merge conflicts
- [x] Tested on browser device
- [x] Tested on Mobile device
