### PR TITLE
refactor/ next-seo integration

### DIFF
--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -1,13 +1,26 @@
+const title = 'Estartando devs';
+const description =
+  'Acreditamos no poder de transformação social através da tecnologia';
+
 export default {
-  description:
-    'Acreditamos no poder de transformação social através da tecnologia',
+  titleTemplate: `${title} | %s`,
+  defaultTitle: title,
+  description,
   canonical: 'https://estartandodevs.com.br/',
   openGraph: {
     type: 'website',
     locale: 'pt_BR',
     url: 'https://estartandodevs.com.br',
-    site_name: 'Estartando Devs',
-    description:
-      'Acreditamos no poder de transformação social através da tecnologia',
+    site_name: title,
+    title,
+    description,
+    images: [
+      {
+        url: 'https://media-exp1.licdn.com/dms/image/C4E0BAQHRvyVjtJ8VOQ/company-logo_200_200/0/1647105778991?e=2147483647&v=beta&t=cIgrEVmzAxgN5k4CQnCTNKBgXkJDOIufdqTeHcWzsHk',
+        width: 200,
+        height: 200,
+        alt: title,
+      },
+    ],
   },
 };

--- a/src/components/IdCard/index.tsx
+++ b/src/components/IdCard/index.tsx
@@ -8,6 +8,7 @@ import * as S from './styles';
 
 export type IdCardProps = {
   name?: string;
+  team?: boolean;
   image?: {
     src: string;
     alt: string;
@@ -21,6 +22,7 @@ export type IdCardProps = {
 
 export const IdCard = ({
   name = 'estartando devs',
+  team,
   course = 'dev backend',
   address = {
     city: 'rio de janeiro',
@@ -58,7 +60,7 @@ export const IdCard = ({
               </S.LocalContainer>
               <S.CourseContainer>
                 <Typography weight="400" variant="body1" color="#b3b3b3">
-                  Curso no Estartando Devs
+                  {team ? 'Monitoria no Curso' : 'Curso no Estartando Devs'}
                 </Typography>
                 <S.CourseTitle
                   course={courseKey}
@@ -79,7 +81,8 @@ export const IdCard = ({
               <S.Image {...imageSrc} />
             </S.ImageContainer>
             <S.Text weight="500" variant="body2">
-              Estudante 2022 @ <strong>estartandodevs</strong>.com.br
+              {team ? 'Equipe' : 'Estudante'} 2022 @{' '}
+              <strong>estartandodevs</strong>.com.br
             </S.Text>
           </S.PhotoContainer>
         </S.CardBackground>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,23 +1,13 @@
+import React from 'react';
+import Link from 'next/link';
 import { Box } from '@chakra-ui/react';
 import { NextSeo } from 'next-seo';
-import Link from 'next/link';
-import React from 'react';
 import { Footer, Layout, Logo, Typography } from '../components';
 
 export default function NotfoundPage() {
   return (
     <Layout full>
-      <NextSeo
-        title="Estartando Devs | 404"
-        description="Tire suas dúvidas sobre nosso processo seletivo."
-        openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
-        }}
-      />
+      <NextSeo title="404" description="Oops! Página não encontrada.." />
       <Box height="100%" display="flex" flexDirection="column" gap="2rem">
         <Box padding="2.5rem">
           <header>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,7 +13,6 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>
       <Head>
-        <title>Estartando Devs</title>
         <meta
           name="google-site-verification"
           content="8kDtWUmUQEh7QXoj_shRaxcgYAVpHs_YQ7TeniN0kmI"
@@ -23,14 +22,6 @@ function App({ Component, pageProps }: AppProps) {
         <meta name="apple-mobile-web-app-status-bar-style" content="#81CAA8" />
         <meta name="msapplication-navbutton-color" content="#81CAA8" />
         <link rel="manifest" href="/manifest.json" />
-        <meta
-          name="description"
-          content="Acreditamos no poder de transformação social através da tecnologia."
-        />
-        <meta
-          property="og:image"
-          content="https://media-exp1.licdn.com/dms/image/C4E0BAQHRvyVjtJ8VOQ/company-logo_200_200/0/1647105778991?e=2147483647&v=beta&t=cIgrEVmzAxgN5k4CQnCTNKBgXkJDOIufdqTeHcWzsHk"
-        />
       </Head>
       <GlobalStyles />
       <DefaultSeo {...SEO} />

--- a/src/pages/id-card/[email].tsx
+++ b/src/pages/id-card/[email].tsx
@@ -84,14 +84,10 @@ export default function MyIdCard({
   return (
     <Layout>
       <NextSeo
-        title="Estartando Devs | Id Card"
-        description="Crie seu ID Card personalizado e divulge nas suas redes. Não esqueça de nos marcar."
+        title={`Id Card - @${profile.name}`}
+        description="Agora você pode compartilhar seu id card. Não esqueça de nos marcar."
         openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
+          url: 'https://estartandodevs.com.br/id-card',
         }}
       />
       <Box

--- a/src/pages/id-card/index.tsx
+++ b/src/pages/id-card/index.tsx
@@ -1,5 +1,5 @@
-import { NextSeo } from 'next-seo';
 import React from 'react';
+import { NextSeo } from 'next-seo';
 import { Box } from '@chakra-ui/react';
 import { Layout, Footer, IdCardForm } from '../../components';
 
@@ -7,14 +7,10 @@ export default function IdCard() {
   return (
     <Layout>
       <NextSeo
-        title="Estartando Devs | Id Card"
+        title="Id Card"
         description="Crie seu ID Card personalizado e divulge nas suas redes. Não esqueça de nos marcar."
         openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
+          url: 'https://estartandodevs.com.br/id-card',
         }}
       />
       <Box

--- a/src/pages/id-card/time/[name].tsx
+++ b/src/pages/id-card/time/[name].tsx
@@ -72,14 +72,10 @@ export default function MyIdCard({
   return (
     <Layout>
       <NextSeo
-        title="Estartando Devs | Id Card"
-        description="Crie seu ID Card personalizado e divulge nas suas redes. Não esqueça de nos marcar."
+        title={`Id Card - @${profile.name}`}
+        description="Agora você pode compartilhar seu id card. Não esqueça de nos marcar."
         openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
+          url: 'https://estartandodevs.com.br/id-card/time',
         }}
       />
       <Box

--- a/src/pages/id-card/time/[name].tsx
+++ b/src/pages/id-card/time/[name].tsx
@@ -24,6 +24,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 
   const profile = {
     name: query?.name,
+    team: true,
     image: {
       src: 'https://res.cloudinary.com/elite-devs/images/logo',
       alt: `imagem monitor(a) ${query?.name}`,

--- a/src/pages/id-card/time/index.tsx
+++ b/src/pages/id-card/time/index.tsx
@@ -7,14 +7,10 @@ export default function IdCardTeam() {
   return (
     <Layout>
       <NextSeo
-        title="Estartando Devs | Id Card Time"
+        title="Id Card Time"
         description="Crie seu ID Card personalizado e divulge nas suas redes. Não esqueça de nos marcar."
         openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
+          url: 'https://estartandodevs.com.br/id-card/time',
         }}
       />
       <Box

--- a/src/pages/perguntas-frequentes.tsx
+++ b/src/pages/perguntas-frequentes.tsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import { GetStaticProps } from 'next';
 import { NextSeo } from 'next-seo';
-import React from 'react';
 import {
   Layout,
   Footer,
@@ -45,14 +45,10 @@ export default function PerguntasFrequentes(props: CommonQuestionsProps) {
   return (
     <Layout>
       <NextSeo
-        title="Estartando Devs | Perguntas Frequentes"
+        title="Perguntas Frequentes"
         description="Tire suas dúvidas sobre nosso processo seletivo."
         openGraph={{
-          type: 'website',
-          locale: 'pt_BR',
-          url: 'https://estartandodevs.com.br',
-          site_name: 'Estartando Devs',
-          title: 'Estartando Devs',
+          url: 'https://estartandodevs.com.br/perguntas-frequentes',
         }}
       />
       <CommonQuestions {...props} />


### PR DESCRIPTION
## Description

Estavamos devendo quanto a configuração desse recurso. adicionei configurações default e juntei as metas tags que estavam sendo usadas no `_app`, deixando apenas o `next-seo` responsável por montar as metas tags.

[link da documentação](https://github.com/garmeeh/next-seo#nextseo-options)

## Developer Checks

- [x] PR title & commits adhere to [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR is targeting correct branch, is up-to-date, & no merge conflicts
- [x] Tested on browser device
- [x] Tested on Mobile device
