### PR TITLE
refactor/ apply improvements off seo to common questions page

### DIFF
--- a/src/components/CommonQuestions/index.tsx
+++ b/src/components/CommonQuestions/index.tsx
@@ -24,7 +24,7 @@ export const CommonQuestions = ({ title, questions }: CommonQuestionsProps) => (
     </header>
 
     <S.CommonQestionsSectionTitle
-      variant="h2"
+      variant="h1"
       color="white"
       dangerouslySetInnerHTML={{ __html: title }}
     />
@@ -32,9 +32,9 @@ export const CommonQuestions = ({ title, questions }: CommonQuestionsProps) => (
       <S.QuestionsWrapper>
         {questions.map(({ key, question, answer }) => (
           <S.Question key={key}>
-            <Typography variant="body1" weight="700">
+            <S.QuestionTitle variant="h3" weight="700">
               {question}
-            </Typography>
+            </S.QuestionTitle>
             <Typography variant="body2" weight="500">
               {answer}
             </Typography>

--- a/src/components/CommonQuestions/styles.ts
+++ b/src/components/CommonQuestions/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Typography } from '../Typography';
 
 export const CommonQuestionsSection = styled.section`
@@ -19,6 +19,12 @@ export const CommonQuestionsSection = styled.section`
 `;
 
 export const CommonQestionsSectionTitle = styled(Typography)`
+  ${({ theme: { typography }, weight }) => css`
+    font-size: ${typography.h2?.fontSize};
+    font-family: ${typography.h2?.fontFamily};
+    font-weight: ${weight || typography.h2?.fontWeight};
+    line-height: ${typography.h2?.lineHeight};
+  `}
   span {
     font-size: 3rem;
     line-height: 3.5rem;
@@ -53,4 +59,13 @@ export const Question = styled.div`
   @media (max-width: ${({ theme: { media } }) => media.tablet}) {
     gap: 1rem;
   }
+`;
+
+export const QuestionTitle = styled(Typography)`
+  ${({ theme: { typography }, weight }) => css`
+    font-size: ${typography.body1?.fontSize};
+    font-family: ${typography.body1?.fontFamily};
+    font-weight: ${weight || typography.body1?.fontWeight};
+    line-height: ${typography.body1?.lineHeight};
+  `}
 `;


### PR DESCRIPTION
## Description

A página de perguntas frequentes não tinha `h1`, e os títulos das perguntas não estavam com hierarquia adequada em relação as respostas. O que é ruim para seo.

## Developer Checks

- [x] PR title & commits adhere to [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR is targeting correct branch, is up-to-date, & no merge conflicts
- [x] Tested on browser device
- [x] Tested on Mobile device
