### PR TITLE
Lighthouse performance improvement

### DIFF
--- a/src/components/Modalities/index.tsx
+++ b/src/components/Modalities/index.tsx
@@ -93,6 +93,8 @@ export const Modalities = () => {
                 <img
                   src={modality.bg}
                   alt={modality.title}
+                  loading="lazy"
+                  decoding="async"
                   className="w-full h-full object-cover transition-transform duration-1000 group-hover:scale-110 opacity-70 group-hover:opacity-100"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-surface-container/90 via-surface-container/40 to-transparent" />

--- a/src/components/StudentProfile/index.tsx
+++ b/src/components/StudentProfile/index.tsx
@@ -41,6 +41,8 @@ export const StudentProfile = ({ title }: studentSectionProfile) => (
       <img
         src="/perfil-aluno-bg.webp"
         alt=""
+        loading="lazy"
+        decoding="async"
         className="w-full h-full object-cover object-right"
       />
     </div>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,28 @@
 import { DefaultSeo } from 'next-seo';
 import { AppProps } from 'next/app';
+import { Open_Sans, Ubuntu } from 'next/font/google';
 import Head from 'next/head';
 import NextNProgress from 'nextjs-progressbar';
 import SEO from '../../next-seo.config';
 import '../styles/globals.css';
 
+const openSans = Open_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-open-sans',
+});
+
+const ubuntu = Ubuntu({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  display: 'swap',
+  variable: '--font-ubuntu',
+});
+
 function App({ Component, pageProps }: AppProps) {
   return (
-    <>
+    <div className={`${openSans.variable} ${ubuntu.variable}`}>
       <Head>
         <meta
           name="google-site-verification"
@@ -27,7 +42,7 @@ function App({ Component, pageProps }: AppProps) {
         height={3}
       />
       <Component {...pageProps} />
-    </>
+    </div>
   );
 }
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,23 +6,6 @@ export default class MyDocument extends Document {
     return (
       <Html lang="pt-BR">
         <Head>
-          <link
-            href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
-            rel="stylesheet"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap"
-            rel="stylesheet"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap"
-            rel="stylesheet"
-          />
-
-          <link
-            href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;500;700&display=swap"
-            rel="stylesheet"
-          />
           <Analytics />
         </Head>
         <body>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600;700&family=Ubuntu:wght@400;500;700;900&display=swap');
 @import "tailwindcss";
 @plugin "daisyui";
 
@@ -13,8 +12,8 @@
   --color-primary-main: var(--color-brand-teal);
   --color-primary-dark: #008f7a;
   
-  --font-sans: "Open Sans", ui-sans-serif, system-ui, sans-serif;
-  --font-display: "Ubuntu", sans-serif;
+  --font-sans: var(--font-open-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-ubuntu), sans-serif;
 
   --color-background-paper: var(--color-surface-container);
   --color-background-default: var(--color-surface-dark);


### PR DESCRIPTION
### ISSUE: - 

  ## Description

  Improved mobile Lighthouse performance score from **71 → 89** (+18) by eliminating two render/bandwidth bottlenecks on the homepage:

  - **Self-hosted fonts via `next/font/google`** — replaced four render-blocking `<link>` tags to `fonts.googleapis.com` in `_document.tsx` and one `@import
  url(...)` in `globals.css` with `next/font/google` (`Open_Sans`, `Ubuntu`). `Ubuntu Mono` was loaded but unused in the codebase, so it was dropped
  entirely. CSS variables (`--font-open-sans`, `--font-ubuntu`) wire into the existing `--font-sans` / `--font-display` design tokens so no consumer code
  changes.
  - **Lazy-loaded below-fold images** — added `loading="lazy" decoding="async"` to three large raw `<img>` tags in `StudentProfile` and `Modalities`
  (`perfil-aluno-bg.webp`, `impulso.png`, `estartando.png` — ~1 MB combined). These were downloading eagerly in parallel with the LCP banner and starving it
  of bandwidth under slow-4G throttling, despite the banner already having `priority`.

  Median-of-3 Lighthouse results (mobile, headless Chrome 148, default-mobile throttling):

  | Metric | Before | After | Δ |
  |---|---|---|---|
  | Performance score | 71 | **89** | **+18** |
  | LCP | 9761 ms | **3989 ms** | −5772 ms |
  | FCP | 2720 ms | 910 ms | −1810 ms |
  | Speed Index | 2769 ms | 1492 ms | −1277 ms |
  | TBT | 11 ms | 0 ms | −11 ms |
  | CLS | 0.00 | 0.00 | — |

  ## Dev Notes

  - The header banner LCP image (`next/legacy/image` w/ `priority`, Cloudinary loader) was not the root cause — it was already prioritized. The cost was
  bandwidth contention from non-LCP raw `<img>` tags. The biggest single win came from lazy-loading two components below the fold, not from touching the LCP
  element itself.
  - LCP is now at 3989 ms — in "needs improvement" (good < 2500). A follow-up pass could target the Cloudinary banner directly (verify response size for
  mobile DPR, consider migrating off `next/legacy/image` to the modern `next/image`, evaluate explicit preload).
  - `next/font` requires the variables to be applied to a DOM ancestor — wrapped `<Component />` in a `<div>` in `_app.tsx` carrying `` `${openSans.variable}
   ${ubuntu.variable}` ``.

  ## Testing

  ### Steps

  1. `yarn build && yarn start`
  2. Open `http://localhost:3000/` in Chrome DevTools → Network: confirm no requests to `fonts.googleapis.com` or `fonts.gstatic.com`; fonts are served from
  `/_next/static/media/*.woff2`.
  3. Scroll the homepage to the **Profile do Aluno** section — `perfil-aluno-bg.webp` should only download as it approaches the viewport (Network → filter
  Img).
  4. Continue to the **Modalidades** section — `impulso.png` and `estartando.png` should similarly load on demand.
  5. Visually verify Open Sans (body copy) and Ubuntu (`.font-display` headings) render correctly across the homepage, Header CTAs, subscriber pages, and
  modals (`ConfirmationModal`, `ErrorModal`, `RequirementsModal`).
  6. Run a Lighthouse mobile audit on `/` and confirm score ≥ 85.
  7. Verify no FOUT / layout shift on first paint (`display: 'swap'` is set; CLS should stay at 0).

  ## Screenshots / Videos
  
All tests are local performed running local server by `yarn run build && yarn run start` and Lighthouse on Google Chrome Devtolls in a incognito window

### Before (Main Branch)

##### Desktop

<img width="989" height="838" alt="image" src="https://github.com/user-attachments/assets/208441c2-00dc-41d4-b08d-d98cedd3a7e7" />


##### Mobile

<img width="987" height="837" alt="image" src="https://github.com/user-attachments/assets/289c933f-2d55-491b-9572-0fc43221034f" />
  
### After Changes
  
##### Desktop
  
<img width="1213" height="838" alt="image" src="https://github.com/user-attachments/assets/6e4ee6f5-13d8-4751-b7bc-5081255925a3" />
  
##### Mobile
  
<img width="1216" height="832" alt="image" src="https://github.com/user-attachments/assets/d6e4e014-f4d3-4f1d-a48e-563f70fa307d" />

  

  
  

  ## Developer Checks

  - [x] PR title & commits adhere to [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] PR is targeting correct branch, is up-to-date, & no merge conflicts
  - [x] Tested on browser device
  - [ ] Tested on Mobile device