### PR TITLE
Improve layout responsiveness across components

### DIFF
--- a/src/components/Footer/SocialShareButtons/index.tsx
+++ b/src/components/Footer/SocialShareButtons/index.tsx
@@ -5,7 +5,7 @@ export const SocialShareButtons = () => {
   const { socialLinks } = useSocialButtons();
 
   return (
-    <div className="flex gap-4 items-center justify-center">
+    <div className="flex gap-4 items-center">
       {socialLinks.map(({ title, href, iconProps, icon: Icon }) => (
         <Link key={title} href={href} target="_blank" rel="noreferrer noopener">
           <div

--- a/src/components/ListApprovedCourses/ApprovedCourses.tsx
+++ b/src/components/ListApprovedCourses/ApprovedCourses.tsx
@@ -54,29 +54,28 @@ export const ApprovedCourses = ({
       className={`w-full group rounded-3xl border ${style.border} ${style.bg} backdrop-blur-xl transition-all duration-500 overflow-hidden mb-8 shadow-2xl hover:shadow-${approvedCourse.color}/10`}
     >
       {/* Header Info */}
-      <div className="p-8 md:p-10 flex flex-col md:flex-row md:items-center justify-between gap-8">
-        <div className="flex items-start gap-6">
+      <div className="p-6 md:p-10 flex flex-col md:flex-row md:items-center justify-between gap-6 md:gap-8">
+        <div className="flex flex-col sm:flex-row items-start gap-4 md:gap-6">
           <div
-            className={`w-16 h-16 rounded-2xl ${style.badge}/20 border ${style.border} flex items-center justify-center shrink-0`}
+            className={`w-12 h-12 md:w-16 md:h-16 rounded-2xl ${style.badge}/20 border ${style.border} flex items-center justify-center shrink-0`}
           >
-            <Trophy className={`w-8 h-8 ${style.text}`} />
+            <Trophy className={`w-6 h-6 md:w-8 md:h-8 ${style.text}`} />
           </div>
           <div className="space-y-2">
-            <div className="flex items-center gap-3">
+            <div className="flex flex-wrap items-center gap-2 md:gap-3">
               <span
-                className={`text-[10px] font-black uppercase tracking-[0.3em] ${style.text}`}
+                className={`text-[10px] font-black uppercase tracking-[0.2em] md:tracking-[0.3em] ${style.text}`}
               >
                 Aprovados 2026
               </span>
-              <div className="w-1.5 h-1.5 rounded-full bg-white/20" />
+              <div className="hidden sm:block w-1.5 h-1.5 rounded-full bg-white/20" />
               <div className="flex items-center gap-1.5 text-white/40 text-[10px] font-bold uppercase tracking-widest">
                 <Users className="w-3 h-3" /> {approvedCourse.students.length}{' '}
                 Selecionados
               </div>
             </div>
             <Typography
-              variant="h2"
-              className="text-3xl md:text-4xl text-white font-black tracking-tight"
+              className="text-xl sm:text-2xl md:text-3xl lg:text-4xl text-white font-black tracking-tight"
             >
               {approvedCourse.course}
             </Typography>
@@ -85,7 +84,7 @@ export const ApprovedCourses = ({
 
         <button
           onClick={() => setIsOpen(!isOpen)}
-          className={`flex items-center gap-3 px-8 py-3.5 rounded-2xl font-black text-sm uppercase tracking-widest transition-all ${
+          className={`flex items-center justify-center gap-3 px-6 md:px-8 py-3 md:py-3.5 rounded-2xl font-black text-xs md:text-sm uppercase tracking-widest transition-all cursor-pointer ${
             isOpen
               ? 'bg-white/10 text-white border border-white/10'
               : `${style.badge} text-surface-dark shadow-lg`

--- a/src/components/SelectiveProcess/index.tsx
+++ b/src/components/SelectiveProcess/index.tsx
@@ -21,7 +21,7 @@ export const SelectiveProcess = ({
           >
             <Typography
               variant="h2"
-              className="text-[40px] md:text-[56px] font-black text-white leading-[1.1] uppercase italic [&>span]:text-brand-teal"
+              className="text-[40px] md:text-[56px] font-black text-white leading-[1.1] uppercase italic tracking-tighter pr-8 [&>span]:text-brand-teal"
               dangerouslySetInnerHTML={{ __html: title }}
             />
             <div className="w-24 h-2 bg-brand-teal rounded-full" />
@@ -35,23 +35,23 @@ export const SelectiveProcess = ({
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: idx * 0.2 }}
-                className="group p-8 rounded-3xl bg-surface-container/40 border border-white/5 hover:border-brand-teal/30 transition-all shadow-xl relative overflow-hidden"
+                className="group p-5 md:p-8 rounded-3xl bg-surface-container/40 border border-white/5 hover:border-brand-teal/30 transition-all shadow-xl relative overflow-hidden"
               >
                 <div className="absolute -right-4 -top-4 w-24 h-24 bg-brand-teal/5 rounded-full blur-2xl group-hover:bg-brand-teal/10 transition-all" />
-                <div className="flex items-start gap-6 relative z-10">
-                  <div className="w-12 h-12 rounded-2xl bg-brand-teal/10 border border-brand-teal/20 flex items-center justify-center shrink-0">
-                    <span className="font-display font-black text-brand-teal text-xl">
-                      {idx + 1}
-                    </span>
-                  </div>
-                  <div className="space-y-3">
-                    <h3 className="text-xl font-display font-black text-white uppercase tracking-tight group-hover:text-brand-teal transition-colors">
+                <div className="relative z-10 space-y-4">
+                  <div className="flex items-center gap-3 md:gap-6">
+                    <div className="w-8 h-8 md:w-12 md:h-12 rounded-lg md:rounded-2xl bg-brand-teal/10 border border-brand-teal/20 flex items-center justify-center shrink-0">
+                      <span className="font-display font-black text-brand-teal text-base md:text-xl">
+                        {idx + 1}
+                      </span>
+                    </div>
+                    <h3 className="text-base md:text-xl font-display font-black text-white uppercase tracking-tight group-hover:text-brand-teal transition-colors">
                       {stage.title}
                     </h3>
-                    <p className="text-white/50 leading-relaxed font-medium">
-                      {stage.description}
-                    </p>
                   </div>
+                  <p className="text-xs md:text-base text-white/50 leading-relaxed font-medium w-full px-1">
+                    {stage.description}
+                  </p>
                 </div>
               </motion.div>
             ))}

--- a/src/components/StudentCharacteristicsCard/index.tsx
+++ b/src/components/StudentCharacteristicsCard/index.tsx
@@ -17,10 +17,8 @@ export const StudentCharacteristicsCard = ({
 
   return (
     <motion.div
-      whileHover={{ scale: 1.05, x: index % 2 === 0 ? 5 : -5 }}
-      className={`relative w-full max-w-[320px] p-6 rounded-2xl bg-surface-container/30 border border-white/5 backdrop-blur-sm flex items-center gap-5 group transition-all hover:border-brand-teal/30 hover:bg-surface-container/50 shadow-xl ${
-        index % 2 === 0 ? 'self-start' : 'self-end'
-      }`}
+      whileHover={{ scale: 1.02, x: index % 2 === 0 ? 5 : -5 }}
+      className={`relative w-full p-6 rounded-2xl bg-surface-container/30 border border-white/5 backdrop-blur-sm flex items-center gap-5 group transition-all hover:border-brand-teal/30 hover:bg-surface-container/50 shadow-xl`}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-brand-teal/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity rounded-2xl" />
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -49,6 +49,10 @@
   html {
     @apply scroll-smooth;
   }
+
+  button {
+    @apply cursor-pointer;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
### [ISSUE]()

# Description
Esta PR realiza correções de responsividade no site. Foram encontrados problemas com alinhamentos e tamanhos de tipografia, causando uma renderização incorreta em dispositivos móveis e desktop.

## Dev Notes
Todos os layouts mobile foram testados utilizando as dimensões do iPhone 17.
Todos os layouts desktop foram testados em um MacBook Air 2024.

## Testing
### Steps
1. Acesse a página inicial do site
2. As mudanças serão perceptíveis diretamente na página inicial, sem necessidade de navegação adicional
3. Para validar os comportamentos mobile, utilize as ferramentas de desenvolvedor do navegador e simule as dimensões do iPhone 17

## Screenshots / Videos

### Problemas encontrados:

#### Overflow no card `ApprovedCourses`
Os títulos dos cards não estavam respeitando os limites do container no mobile, resultando em overflow e desalinhamento do layout.

Atual:
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/b418cbcd-d05d-4d9e-b958-35b0d47d6c35" />

Correção:
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/15733251-4d74-4156-89b5-20bd8e3dc9b7" />

---

#### Botões não possuem indicação de que são clicáveis
https://github.com/user-attachments/assets/41b536ee-bfa1-4a57-b11c-750b21c5d998

Correção:

https://github.com/user-attachments/assets/d5f3bf9d-b6ef-49a3-9fb4-7f51ce3303ac



---

#### Cards da direita não ocupam 100% do espaço disponível
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/42b5aa97-354b-441a-94d7-6a697dbe65e4" />

Correção:
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/32af9e72-dbb4-4d7e-baed-b304d97470ae" />

---

#### Componente `SocialShareIcons` não está alinhado com os elementos do footer
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/08ea6aa4-3d64-4df1-a1fe-7e9202c0a31c" />

Correção:
<img width="1710" height="1112" alt="image" src="https://github.com/user-attachments/assets/5e948930-de9e-4fd0-8759-5ab42abb60a4" />

---

## Developer Checks
- [x] PR title & commits adhere to [[Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] PR is targeting correct branch, is up-to-date, & no merge conflicts
- [x] Tested on browser device
- [x] Tested on Mobile device